### PR TITLE
feat(#3): support custom Consul service entry mapper

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,8 +1,10 @@
 package consul
 
 import (
-	"github.com/nbio/st"
 	"testing"
+
+	consul "github.com/hashicorp/consul/api"
+	"github.com/nbio/st"
 )
 
 func TestConfig(t *testing.T) {
@@ -27,4 +29,13 @@ func TestConfig(t *testing.T) {
 	bar := config.Instances[0]
 	st.Expect(t, bar.Token, "")
 	st.Expect(t, bar.Datacenter, "")
+}
+
+func TestMapConsulEntries(t *testing.T) {
+	service := &consul.ServiceEntry{
+		Node:    &consul.Node{Node: "foo", Address: "127.0.0.1"},
+		Service: &consul.AgentService{Service: "foo", Port: 80},
+	}
+	list := []*consul.ServiceEntry{service}
+	st.Expect(t, MapConsulEntries(list), []string{"127.0.0.1:80"})
 }

--- a/consul_test.go
+++ b/consul_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"testing"
 
+	consul "github.com/hashicorp/consul/api"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v0"
 	"gopkg.in/vinxi/utils.v0"
@@ -20,6 +21,37 @@ func TestConsulSimpleClient(t *testing.T) {
 		BodyString(consulResponse)
 
 	config := NewConfig("web", "http://demo.consul.io")
+	gock.InterceptClient(config.Instances[0].HttpClient)
+	consul := New(config)
+
+	w := utils.NewWriterStub()
+	req := &http.Request{URL: &url.URL{}}
+
+	var called bool
+	consul.HandleHTTP(w, req, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	st.Expect(t, called, true)
+	st.Expect(t, req.Host, "127.0.0.1:80")
+	st.Expect(t, req.URL.Host, "127.0.0.1:80")
+	st.Expect(t, w.Code, 200)
+	st.Expect(t, string(w.Body), "")
+}
+
+func TestConsulCustomMapper(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://consul.io").
+		Get("/v1/health/service/web").
+		Reply(200).
+		Type("json").
+		BodyString(consulResponse)
+
+	config := NewConfig("web", "http://demo.consul.io")
+	config.Mapper = func(list []*consul.ServiceEntry) []string {
+		return MapConsulEntries(list)
+	}
 	gock.InterceptClient(config.Instances[0].HttpClient)
 	consul := New(config)
 


### PR DESCRIPTION
Configurable mapper function to map (and filter) Consul service entries into `[]string` = host + port scheme.
